### PR TITLE
Add PopScore endpoints

### DIFF
--- a/IGDB.Tests/PopScore.cs
+++ b/IGDB.Tests/PopScore.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using IGDB.Models;
+using Xunit;
+
+namespace IGDB.Tests
+{
+	public class PopScore
+	{
+		IGDBClient _api;
+
+		public PopScore()
+		{
+			_api = new IGDB.IGDBClient(
+			  Environment.GetEnvironmentVariable("IGDB_CLIENT_ID"),
+			  Environment.GetEnvironmentVariable("IGDB_CLIENT_SECRET")
+			);
+		}
+
+		[Fact]
+		public async Task ShouldReturnAllPopularityTypes()
+		{
+			var popularityTypes = await _api.QueryAsync<PopularityType>(IGDBClient.Endpoints.PopularityTypes, "fields *;");
+
+			Assert.NotNull(popularityTypes);
+			foreach (var popularityType in popularityTypes)
+			{
+				Assert.NotNull(popularityType.Checksum);
+				Assert.NotNull(popularityType.CreatedAt);
+				Assert.NotNull(popularityType.Name);
+				Assert.NotNull(popularityType.PopularitySource);
+				Assert.NotNull(popularityType.UpdatedAt);
+			}
+		}
+
+		[Fact]
+		public async Task ShouldReturnLimitedPopularityPrimitives()
+		{
+			var popularityPrimitives = await _api.QueryAsync<PopularityPrimitive>(
+				IGDBClient.Endpoints.PopularityPrimitives,
+				"fields *; limit 10;");
+
+			Assert.NotNull(popularityPrimitives);
+			Assert.True(popularityPrimitives.Length == 10);
+
+			foreach (var popularityPrimitive in popularityPrimitives)
+			{
+				Assert.NotNull(popularityPrimitive.CalculatedAt);
+				//Assert.NotNull(popularityPrimitive.Checksum);
+				Assert.NotNull(popularityPrimitive.CreatedAt);
+				Assert.NotNull(popularityPrimitive.PopularitySource);
+				Assert.NotNull(popularityPrimitive.PopularityType);
+				Assert.NotNull(popularityPrimitive.UpdatedAt);
+				Assert.NotNull(popularityPrimitive.Value);
+			}
+		}
+	}
+}

--- a/IGDB/IGDBApi.cs
+++ b/IGDB/IGDBApi.cs
@@ -284,6 +284,8 @@ namespace IGDB
       public const string PlatformVersionReleaseDates = "platform_version_release_dates";
       public const string PlatformWebsites = "platform_websites";
       public const string PlayerPerspectives = "player_perspectives";
+	  public const string PopularityPrimitives = "popularity_primitives";
+	  public const string PopularityTypes = "popularity_types";
       public const string ReleaseDates = "release_dates";
       public const string Screenshots = "screenshots";
       public const string Search = "search";

--- a/IGDB/Models/PopularityPrimitive.cs
+++ b/IGDB/Models/PopularityPrimitive.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace IGDB.Models
+{
+	public class PopularityPrimitive : ITimestamps //, IHasChecksum
+	{
+		public DateTimeOffset? CalculatedAt { get; set; }
+		/*
+		 * Even though the IGDB API documentation states that the checksum field
+		 * is available for this model, the API does not return it. This is why
+		 * the Checksum property is commented out for now.
+		 */
+		//public string Checksum { get; set; }
+		public DateTimeOffset? CreatedAt { get; set; }
+		public long? GameId { get; set; }
+		public PopularitySource? PopularitySource { get; set; }
+		public IdentityOrValue<PopularityType> PopularityType { get; set; }
+		public DateTimeOffset? UpdatedAt { get; set; }
+		public decimal? Value { get; set; }
+	}
+}

--- a/IGDB/Models/PopularitySource.cs
+++ b/IGDB/Models/PopularitySource.cs
@@ -1,0 +1,7 @@
+namespace IGDB.Models
+{
+	public enum PopularitySource
+	{
+		Igdb = 121
+	}
+}

--- a/IGDB/Models/PopularityType.cs
+++ b/IGDB/Models/PopularityType.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace IGDB.Models
+{
+	public class PopularityType : ITimestamps, IHasChecksum
+	{
+		public string Checksum { get; set; }
+		public DateTimeOffset? CreatedAt { get; set; }
+		public string Name { get; set; }
+		public PopularitySource? PopularitySource { get; set; }
+		public DateTimeOffset? UpdatedAt { get; set; }
+	}
+}


### PR DESCRIPTION
Even though the IGDB API documentation states that the checksum field is available for the Popularity Primitive model, the API does not return it. This is why the Checksum property is commented out for now.